### PR TITLE
Skip broken python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 # linkml-run-examples output (not useful to have in git in its current form)
 /examples/output/
 
+# Local stuff
+.bash_history_local
+.envrc
+
 # Derived schemas, generated from the schema.yaml
 tmp/
 project/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9,<3.14"
 dynamic = ["version"]
 
 dependencies = [


### PR DESCRIPTION
We can prevent uv from defaulting to the newest version of python by updating the toml file.  Making this a draft since I haven't looked at the GHA to see if 3.14 is there and should be removed. 