### PR TITLE
🐛 Update PR builds to use just

### DIFF
--- a/.github/workflows/test_pages_build.yaml
+++ b/.github/workflows/test_pages_build.yaml
@@ -44,12 +44,16 @@ jobs:
         with:
           python-version: 3.13
 
+      - name: Install just
+        run: |
+          uv tool install rust-just
+
       - name: Install dependencies
         run: uv sync --dev --no-progress
 
       - name: Build documentation
         run: |
-          uv run mkdocs build -d site
+          just gen-doc
           touch site/.nojekyll
 
       # https://github.com/rossjrw/pr-preview-action

--- a/.github/workflows/test_pages_build.yaml
+++ b/.github/workflows/test_pages_build.yaml
@@ -54,6 +54,7 @@ jobs:
       - name: Build documentation
         run: |
           just gen-doc
+          uv run mkdocs build -d site
           touch site/.nojekyll
 
       # https://github.com/rossjrw/pr-preview-action


### PR DESCRIPTION
The current version of building test pages isn't adding the details to the build deployments, so I'm changing it to use the same strategies for the main deploy docs.