### PR TITLE
rename slot, relationship

### DIFF
--- a/src/common_access_model/schema/common_access_model.yaml
+++ b/src/common_access_model/schema/common_access_model.yaml
@@ -278,7 +278,7 @@ classes:
     slots:
     - family_relationship_id
     - family_member_id
-    - relationship
+    - relationship_type
     - subject_id
     slot_usage:
       family_relationship_id:
@@ -782,7 +782,7 @@ slots:
     required: true
     range: Subject
     inlined: false
-  relationship:
+  relationship_type:
     description: Code definting the relationship predicate. Relationship of the "Family Member" 
      to the "Subject", eg, mother of.
     required: true

--- a/src/common_access_model/schema/common_access_model.yaml
+++ b/src/common_access_model/schema/common_access_model.yaml
@@ -278,7 +278,7 @@ classes:
     slots:
     - family_relationship_id
     - family_member_id
-    - relationship_type
+    - relation
     - subject_id
     slot_usage:
       family_relationship_id:
@@ -782,7 +782,7 @@ slots:
     required: true
     range: Subject
     inlined: false
-  relationship_type:
+  relation:
     description: Code definting the relationship predicate. Relationship of the "Family Member" 
      to the "Subject", eg, mother of.
     required: true


### PR DESCRIPTION
When trying to load the entire SQL Alchemy model to extract the DDL for schema generation, the slot, relationship, is causing a namespace collision inside the FamilyRelationship model with the SQLA's property with the same name, overriding the ORM functionality with a class member. This results in errors when you try to actually follow the relationships associated with that class. 

This simply renames the slot, relationship, to relationship_type. The new name can be (almost) anything other than 'relationship'. 

Closes #58 