### PR TITLE
Fix formatting of snomed_ct URL in YAML file

### DIFF
--- a/src/common_access_model/schema/common_access_model.yaml
+++ b/src/common_access_model/schema/common_access_model.yaml
@@ -19,7 +19,7 @@ prefixes:
   ig2dac: https://nih-ncpi.github.io/ncpi-fhir-ig-2/CodeSystem/research-data-access-code/
   ig2dat: https://nih-ncpi.github.io/ncpi-fhir-ig-2/CodeSystem/research-data-access-type/
   ig2_biospecimen_availability: https://nih-ncpi.github.io/ncpi-fhir-ig-2/CodeSystem/biospecimen-availability/
-  snomed_ct: 	http://snomed.info/id/
+  snomed_ct: http://snomed.info/id/
   MONDO: http://purl.obolibrary.org/obo/MONDO_
   HP: http://purl.obolibrary.org/obo/HP_
   mesh: http://id.nlm.nih.gov/mesh/


### PR DESCRIPTION
The extra tab here is killing the linter on the downstream models. I don't know why it doesn't complain for the local model, but those children are all whining about it. 