### PR TITLE
Vocabulary tables

### DIFF
--- a/src/common_access_model/schema/common_access_model.yaml
+++ b/src/common_access_model/schema/common_access_model.yaml
@@ -388,12 +388,33 @@ classes:
     title: Concept
     description: A standardized concept with display information.
     slots:
-    - concept_curie
-    - display
+      - concept_curie
+      - vocabulary_id
+      - concept_code
+      - omop_concept_id
+      - display
+      - definition
     slot_usage:
       concept_curie:
         required: true
         identifier: true
+        range: uriorcurie
+  Vocabulary:
+    description: Flat table containing each of the ontologies used for dataset annotations
+    slots:
+      - vocabulary_id
+      - name
+      - vocabulary_uri
+      - fhir_system
+      - prefix
+      - description
+      - version
+      - vocabulary_source 
+    slot_usage:
+      vocabulary_id:
+        identifier: true
+        range: string
+
   Sample:
     title: Sample
     description: A functionally equivalent specimen taken from a participant or processed from such a sample.
@@ -969,6 +990,54 @@ slots:
     title: Display String
     description: The friendly display string of the coded term.
     range: string
+  concept_code:
+    title: Concept Code
+    description: Identifier as it is defined within the ontology
+    required: true
+    range: string
+  omop_concept_id:
+    title: OMOP Concept ID
+    description: The OMOP Concept ID for the term, if applicable
+    range: integer
+  definition:
+    title: Definition
+    description: Detailed definition or description for the term
+    range: string
+  vocabulary_id:
+    title: Vocabulary ID
+    description: The ID associated with the vocabulary or ontology inside the warehouse
+    required: true
+    range: Vocabulary
+  vocabulary_uri:
+    title: Vocabulary URI
+    description: Official URI associated with the vocabulary
+    required: true
+    range: uri
+  fhir_system:
+    title: FHIR System
+    description: System used within FHIR valuesets and codings
+    required: true
+    range: uri
+  prefix:
+    title: Canonical Curie Prefix
+    description: The authoritative namespace prefix allocated to the vocabulary. Used to resolve compact identifiers (CURIEs) to their full semantic URIs or FHIR system URLs.
+    range: string
+    pattern: "^[A-Za-z][A-Za-z0-9_\\-\\.]*$"
+    comments:
+      - "Must start with a letter; thereafter allows letters, digits, underscores, hyphens, and dots to accommodate OLS/UMLS source variability."
+      - "RISK: In order for all of our data to correctly join, the format of the prefix must always align with the prefix used in this table."
+    todos:
+      - "Ensure that MapDragon and TermWeaver both rely on the same rules for prefixes"
+  version:
+    title: Version
+    description: Version associated with the current vocabulary content
+    range: string
+  vocabulary_source:
+    title: Vocabulary data source
+    description: Source used for accessing the vocabulary's content
+    range: string
+    comments:
+      - "This is currently poorly defined because we haven't fully defined the nature of the data pulls. Most likely it will end up as a filename (.owl, .obo, etc) or another tool, etc"
   concept_source:
     title: Concept Source Text
     description: The source text yielding the standardized concept.

--- a/src/common_access_model/schema/common_access_model.yaml
+++ b/src/common_access_model/schema/common_access_model.yaml
@@ -389,9 +389,9 @@ classes:
     description: A standardized concept with display information.
     slots:
       - concept_curie
-      - vocabulary_id
+      - concept_id
+      - vocabulary_prefix
       - concept_code
-      - omop_concept_id
       - display
       - definition
     slot_usage:
@@ -399,22 +399,41 @@ classes:
         required: true
         identifier: true
         range: uriorcurie
+  Synonym:
+    title: Concept Synonym
+    description: Alternate display names for concepts.
+    slots:
+      - concept_curie
+      - display
+      - display_type
+      - language
   Vocabulary:
     description: Flat table containing each of the ontologies used for dataset annotations
     slots:
-      - vocabulary_id
+      - vocabulary_prefix
       - name
       - vocabulary_uri
+      - vocabulary_id
       - fhir_system
-      - prefix
       - description
       - version
       - vocabulary_source 
     slot_usage:
-      vocabulary_id:
+      vocabulary_prefix:
         identifier: true
         range: string
-
+        pattern: "^[A-Za-z][A-Za-z0-9_\\-\\.]*$"
+        comments:
+          - "Must start with a letter; thereafter allows letters, digits, underscores, hyphens, and dots to accommodate OLS/UMLS source variability."
+          - "RISK: In order for all of our data to correctly join, the format of the prefix must always align with the prefix used in this table."
+        todos:
+          - "Ensure that MapDragon and TermWeaver both rely on the same rules for prefixes"
+  ConceptRelationship:
+    description: Relationships between two terms.
+    slots:
+      - concept_curie
+      - target_concept_curie
+      - relationship_curie
   Sample:
     title: Sample
     description: A functionally equivalent specimen taken from a participant or processed from such a sample.
@@ -990,12 +1009,20 @@ slots:
     title: Display String
     description: The friendly display string of the coded term.
     range: string
+  display_type:
+    title: Display Type
+    description: The type of display name, eg, "Preferred".
+    range: string
+  language:
+    title: Language
+    description: The ISO 639 language code of this entity.
+    range: string
   concept_code:
     title: Concept Code
     description: Identifier as it is defined within the ontology
     required: true
     range: string
-  omop_concept_id:
+  concept_id:
     title: OMOP Concept ID
     description: The OMOP Concept ID for the term, if applicable
     range: integer
@@ -1004,10 +1031,9 @@ slots:
     description: Detailed definition or description for the term
     range: string
   vocabulary_id:
-    title: Vocabulary ID
-    description: The ID associated with the vocabulary or ontology inside the warehouse
-    required: true
-    range: Vocabulary
+    title: OMOP Vocabulary ID
+    description: The OMOP Vocabulary ID associated with the vocabulary, if applicable
+    range: string
   vocabulary_uri:
     title: Vocabulary URI
     description: Official URI associated with the vocabulary
@@ -1018,16 +1044,10 @@ slots:
     description: System used within FHIR valuesets and codings
     required: true
     range: uri
-  prefix:
+  vocabulary_prefix:
     title: Canonical Curie Prefix
     description: The authoritative namespace prefix allocated to the vocabulary. Used to resolve compact identifiers (CURIEs) to their full semantic URIs or FHIR system URLs.
-    range: string
-    pattern: "^[A-Za-z][A-Za-z0-9_\\-\\.]*$"
-    comments:
-      - "Must start with a letter; thereafter allows letters, digits, underscores, hyphens, and dots to accommodate OLS/UMLS source variability."
-      - "RISK: In order for all of our data to correctly join, the format of the prefix must always align with the prefix used in this table."
-    todos:
-      - "Ensure that MapDragon and TermWeaver both rely on the same rules for prefixes"
+    range: Vocabulary
   version:
     title: Version
     description: Version associated with the current vocabulary content
@@ -1038,6 +1058,14 @@ slots:
     range: string
     comments:
       - "This is currently poorly defined because we haven't fully defined the nature of the data pulls. Most likely it will end up as a filename (.owl, .obo, etc) or another tool, etc"
+  target_concept_curie:
+    title: Target Concept ID
+    description: The concept to which this term relates
+    range: Concept
+  relationship_curie:
+    title: Mapping Relationship
+    description: The relationship between the subject (this term) and the object (target_concept_id).
+    range: uriorcurie
   concept_source:
     title: Concept Source Text
     description: The source text yielding the standardized concept.

--- a/src/common_access_model/schema/common_access_model.yaml
+++ b/src/common_access_model/schema/common_access_model.yaml
@@ -407,6 +407,13 @@ classes:
       - display
       - display_type
       - language
+  DeprecatedConcept:
+    title: Deprecated Concept
+    description: Identifies concepts that are not currently valid.
+    slots:
+      - concept_curie
+      - deprecation_type
+      - replacement_curie
   Vocabulary:
     description: Flat table containing each of the ontologies used for dataset annotations
     slots:
@@ -1012,6 +1019,14 @@ slots:
   display_type:
     title: Display Type
     description: The type of display name, eg, "Preferred".
+    range: string
+  deprecation_type:
+    title: Deprecation Type
+    description: The type of or reason for deprecation, if known.
+    range: string
+  replacement_curie:
+    title: Replacement CURIE
+    description: A replacement curie for this deprecated concept, if applicable.
     range: string
   language:
     title: Language

--- a/tests/data/valid/Concept-000.yaml
+++ b/tests/data/valid/Concept-000.yaml
@@ -1,2 +1,4 @@
 concept_curie: test_concept:000
 display: Test
+vocabulary_id: test
+concept_code: '000'

--- a/tests/data/valid/Concept-000.yaml
+++ b/tests/data/valid/Concept-000.yaml
@@ -1,4 +1,4 @@
 concept_curie: test_concept:000
 display: Test
-vocabulary_id: test
+vocabulary_prefix: test
 concept_code: '000'

--- a/tests/data/valid/Vocabulary-000.yaml
+++ b/tests/data/valid/Vocabulary-000.yaml
@@ -1,7 +1,6 @@
-vocabulary_id: test
+vocabulary_prefix: test_concept
 name: Test Vocabulary
 vocabulary_uri: https://github.com/include-dcc/common-access-model/blob/main/tests/data/valid/Vocabulary-000.yaml
 fhir_system: https://github.com/include-dcc/common-access-model/blob/main/tests/data/valid/Vocabulary-000.yaml
-prefix: test_concept
 version: '0.1'
 vocabulary_source: https://github.com/include-dcc/common-access-model/blob/main/tests/data/valid/Vocabulary-000.yaml

--- a/tests/data/valid/Vocabulary-000.yaml
+++ b/tests/data/valid/Vocabulary-000.yaml
@@ -1,0 +1,7 @@
+vocabulary_id: test
+name: Test Vocabulary
+vocabulary_uri: https://github.com/include-dcc/common-access-model/blob/main/tests/data/valid/Vocabulary-000.yaml
+fhir_system: https://github.com/include-dcc/common-access-model/blob/main/tests/data/valid/Vocabulary-000.yaml
+prefix: test_concept
+version: '0.1'
+vocabulary_source: https://github.com/include-dcc/common-access-model/blob/main/tests/data/valid/Vocabulary-000.yaml


### PR DESCRIPTION
I have added more complex vocabulary tables. This was based on the work on [MD Terminology Trove](https://github.com/carrollaboratory/md-terminology-trove). I made some tweaks to add a couple of gaps we'd discussed. I've also removed some of the OMOP pieces with an expectation we'd also have OMOP Vocabulary Tables available. We could also lean further into the OMOP conventions and bring those in and supplement with a few of our specific needs.